### PR TITLE
(fix): Incorrect make command under local XMR testnet instructions

### DIFF
--- a/docs/development/installing.md
+++ b/docs/development/installing.md
@@ -89,8 +89,8 @@ If you are a developer who wants to test Haveno in a more controlled way, follow
 
 #### Run a local XMR testnet
 
-1. In a new terminal window run `make monerod-local1`
-1. In a new terminal window run `make monerod-local2`
+1. In a new terminal window run `make monerod1-local`
+1. In a new terminal window run `make monerod2-local`
 3. Now mine the first 150 blocks to a random address before using, so wallets only use the latest output type. Run in one of the terminal windows opened above:
 
 `start_mining 9tsUiG9bwcU7oTbAdBwBk2PzxFtysge5qcEsHEpetmEKgerHQa1fDqH7a4FiquZmms7yM22jdifVAD7jAb2e63GSJMuhY75 1`


### PR DESCRIPTION
## Description
Addresses a minor issue regarding the make command for instructions on running a local XMR testnet The strings `monerod-local1` and `monerod-local2` have been corrected to `monerod1-local` and `monerod2-local` respectively. Aligning with what's in the [main haveno library](https://github.com/haveno-dex/haveno/blob/b0fc86431343a91392608fbd573a34f96ff3b4d1/docs/installing.md?plain=1#L90-L91).

Reference the `Makefile` as well as the root cause of proposed change:

- https://github.com/haveno-dex/haveno/blob/b0fc86431343a91392608fbd573a34f96ff3b4d1/Makefile#L63-L77

## Changes
- Updated make command strings from [this](https://docs.haveno.exchange/development/installing/#run-a-local-test-network) section